### PR TITLE
Switch to GitHub actions (updated)

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -47,3 +47,16 @@ jobs:
       - name: Test
         run: |
           cargo test
+
+      - name: Release
+        if: github.event_name == 'release' && !contains(matrix.rust, 'nightly')
+        run: |
+          cargo build --release
+
+      - name: Upload release binaries
+        uses: actions/upload-artifact@v2
+        if: github.event_name == 'release' && !contains(matrix.rust, 'nightly')
+        with:
+          name: lms-${{ matrix.os }}
+          path: |
+            target/release/lms*

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     outputs:
       os: '["ubuntu-20.04", "windows-2019", "macos-10.15"]'
-      rust: '["1.55.0", "nightly"]'
+      rust: '["stable", "nightly"]'
     steps:
       - run: |
 

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -27,6 +27,19 @@ jobs:
         with:
           toolchain: ${{ matrix.rust }}
 
+      - name: Cache
+        uses: actions/cache@v2
+        with:
+          path: |
+            ~/.cargo/bin/
+            ~/.cargo/registry/index/
+            ~/.cargo/registry/cache/
+            ~/.cargo/git/db/
+            ./target/
+          key: "cache-OS:${{ matrix.os }}-Rust:${{ matrix.rust }}-${{ hashFiles('./Cargo.toml') }}-${{ hashFiles('./Cargo.lock') }}"
+          restore-keys: |
+               "cache-OS:${{ matrix.os }}-Rust:${{ matrix.rust }}"
+
       - name: Build
         run: |
           cargo build

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -1,0 +1,36 @@
+name: CI
+on:
+  pull_request:
+  push:
+    branches:
+      - master
+
+jobs:
+  Test:
+    if: "!contains(github.event.head_commit.message, '[skip ci]')"
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os:
+          - ubuntu-20.04
+          - windows-2019
+          - macos-10.15
+        rust:
+          - 1.55.0
+          - nightly
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Setup rust
+        uses: actions-rs/toolchain@v1
+        with:
+          toolchain: ${{ matrix.rust }}
+
+      - name: Build
+        run: |
+          cargo build
+
+      - name: Test
+        run: |
+          cargo test

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -6,19 +6,25 @@ on:
       - master
 
 jobs:
-  Test:
+  matrix:
+    name: Define Matrix
+    runs-on: ubuntu-latest
+    outputs:
+      os: '["ubuntu-20.04", "windows-2019", "macos-10.15"]'
+      rust: '["1.55.0", "nightly"]'
+    steps:
+      - run: |
+
+  test:
+    needs: matrix
+    name: "Run Tests"
     if: "!contains(github.event.head_commit.message, '[skip ci]')"
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false
       matrix:
-        os:
-          - ubuntu-20.04
-          - windows-2019
-          - macos-10.15
-        rust:
-          - 1.55.0
-          - nightly
+        os: ${{ fromJSON(needs.matrix.outputs.os) }}
+        rust: ${{ fromJSON(needs.matrix.outputs.rust) }}
     steps:
       - uses: actions/checkout@v2
 
@@ -48,15 +54,82 @@ jobs:
         run: |
           cargo test
 
-      - name: Release
-        if: github.event_name == 'release' && !contains(matrix.rust, 'nightly')
+  release:
+    needs:
+      - matrix
+      - test
+    name: Create a Release
+    if: github.event_name == 'release'
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os: ${{ fromJSON(needs.matrix.outputs.os) }}
+        rust:
+          - ${{ fromJSON(needs.matrix.outputs.rust)[0] }}
+        
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Setup rust
+        uses: actions-rs/toolchain@v1
+        with:
+          toolchain: ${{ matrix.rust }}
+
+      - name: Build
         run: |
           cargo build --release
-
+          
       - name: Upload release binaries
         uses: actions/upload-artifact@v2
-        if: github.event_name == 'release' && !contains(matrix.rust, 'nightly')
         with:
           name: lms-${{ matrix.os }}
           path: |
             target/release/lms*
+            
+  coverage:
+    needs:
+      - matrix
+      - test
+    name: Generate Coverage Report
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os:
+          - ${{ fromJSON(needs.matrix.outputs.os)[0] }}
+        rust:
+          - ${{ fromJSON(needs.matrix.outputs.rust)[0] }}
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Setup rust
+        uses: actions-rs/toolchain@v1
+        with:
+          toolchain: ${{ matrix.rust }}
+          
+      - name: Cache
+        uses: actions/cache@v2
+        with:
+          path: |
+            ~/.cargo/bin/
+            ~/.cargo/registry/index/
+            ~/.cargo/registry/cache/
+            ~/.cargo/git/db/
+            ./target/
+          key: "cache:coverage-OS:${{ matrix.os }}-Rust:${{ matrix.rust }}-${{ hashFiles('./Cargo.toml') }}-${{ hashFiles('./Cargo.lock') }}"
+          restore-keys: |
+               "cache:coverage-OS:${{ matrix.os }}-Rust:${{ matrix.rust }}"
+               
+      - name: Install tarpaulin
+        run: |
+          cargo install cargo-tarpaulin
+
+      - name: Generate code coverage
+        run: cargo tarpaulin --timeout 300 --out Xml
+
+      - name: Upload to codecov.io
+        uses: codecov/codecov-action@v2
+        with:
+          fail_ci_if_error: true
+        

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@
   <a href="https://docs.rs/lms"><img src="https://docs.rs/lms/badge.svg" alt="Docs" /></a>
 </p>
 <p align="center">
-  <img src="examples/lumins.gif" alt="Demo"    
+  <img src="examples/lumins.gif" alt="Demo"
 </p>
 
 ## Features
@@ -17,7 +17,7 @@
 <table>
     <tr><td><b>100% Rust</b></td></tr>
     <tr><td><b>Powered by the <a href="https://github.com/rayon-rs/rayon">Rayon</a> library for high parallel perfomance</b></td></tr>
-    <tr><td><b>Supported on Unix-based platforms</b></td></tr>
+    <tr><td><b>Supported on Unix-based platforms or Windows</b></td></tr>
     <tr><td><b>Extremely fast at synchronizing directories with large quantities of files</b></td></tr>
     <tr><td><b>Multithreaded copy, remove, and sync</b></td></tr>
     <tr><td><b>A progress bar using <a href="https://github.com/mitsuhiko/indicatif">indicatif</a></b></td></tr>


### PR DESCRIPTION
I took another stab at it, building on top of https://github.com/wchang22/LuminS/pull/32. I ended up replacing kcov with tarpaulin, which is a Cargo code coverage tool. This is the cleanest/simplest approach I could find. You might be aware that the current code coverage process with kcov has been broken for a while anyway (see line 786 here - https://travis-ci.org/github/wchang22/LuminS/jobs/703374950#L786).

Fixes https://github.com/wchang22/LuminS/issues/27